### PR TITLE
Add ability to easily attach event handlers

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -116,7 +116,10 @@ picker.directive('dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
           modelCtrl.$setViewValue({startDate: start, endDate: end})
         )
         modelCtrl.$render()
-        
+
+      for eventType, callbackFunction of opts.eventHandlers
+        el.on eventType, callbackFunction
+
     _init()
 
     # If input is cleared manually, set dates to null.


### PR DESCRIPTION
Event handlers can now be passed to the daterangepicker directive via the  option's 'eventHandlers' attribute:

$scope.options = {
&nbsp;&nbsp;&nbsp;&nbsp;eventHandlers: {
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'show.daterangepicker': function() { ... }
&nbsp;&nbsp;&nbsp;&nbsp;}
};

Closes #56