### PR TITLE
- fix: only remove when dropdown was initialized

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -159,5 +159,5 @@ picker.directive('dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
       )
 
     $scope.$on '$destroy', ->
-      _picker.remove()
+      _picker?.remove()
 )


### PR DESCRIPTION
When the drop down is not initialized, the component cannot be removed. This happens when having several pages or a popup with showing the picker and switching without opening the drop down.