### PR TITLE
add clearable option

### DIFF
--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -30,12 +30,6 @@
               el.val('');
               el.trigger('change');
             });
-            el.on('apply.daterangepicker', function(ev, picker) {
-              return modelCtrl.$setViewValue({
-                startDate: _picker.startDate,
-                endDate: _picker.endDate
-              });
-            });
           });
           opts = angular.extend(opts, { locale: { cancelLabel: 'Clear' } });
         }
@@ -150,15 +144,17 @@
         };
         _init = function() {
           _picker = el.data('daterangepicker');
-          return el.daterangepicker(opts, function(start, end, label) {
+          var res = el.daterangepicker(opts);
+          el.on('apply.daterangepicker', function(ev, picker) {
             $timeout(function() {
               return modelCtrl.$setViewValue({
-                startDate: start,
-                endDate: end
+                startDate: picker.startDate,
+                endDate: picker.endDate
               });
             });
             return modelCtrl.$render();
           });
+          return res;
         };
         _init();
         el.change(function() {

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -30,6 +30,12 @@
               el.val('');
               el.trigger('change');
             });
+            el.on('apply.daterangepicker', function(ev, picker) {
+              return modelCtrl.$setViewValue({
+                startDate: _picker.startDate,
+                endDate: _picker.endDate
+              });
+            });
           });
           opts = angular.extend(opts, { locale: { cancelLabel: 'Clear' } });
         }

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -16,23 +16,39 @@
         dateMin: '=min',
         dateMax: '=max',
         model: '=ngModel',
-        opts: '=options'
+        opts: '=options',
+        clearable: '='
       },
       link: function($scope, element, attrs, modelCtrl) {
         var customOpts, el, opts, _formatted, _init, _picker, _setEndDate, _setStartDate, _validateMax, _validateMin;
         el = $(element);
         customOpts = $scope.opts;
         opts = angular.extend({}, dateRangePickerConfig, customOpts);
+        if ($scope.clearable) {
+          $timeout(function () {
+            el.on('cancel.daterangepicker', function(ev, picker) {
+              el.val('');
+              el.trigger('change');
+            });
+          });
+          opts = angular.extend(opts, { locale: { cancelLabel: 'Clear' } });
+        }
         _picker = null;
         _setStartDate = function(newValue) {
           return $timeout(function() {
             var m;
             if (_picker) {
-              m = moment(newValue);
-              if (_picker.endDate < m) {
-                _picker.setEndDate(m);
+              if (newValue === null) {
+                _picker.setStartDate();
+                _picker.setEndDate();
+                el.val('');
+              } else {
+                m = moment(newValue);
+                if (_picker.endDate < m) {
+                  _picker.setEndDate(m);
+                }
+                return _picker.setStartDate(m);
               }
-              return _picker.setStartDate(m);
             }
           });
         };
@@ -40,11 +56,17 @@
           return $timeout(function() {
             var m;
             if (_picker) {
-              m = moment(newValue);
-              if (_picker.startDate > m) {
-                _picker.setStartDate(m);
+              if (newValue === null) {
+                _picker.setStartDate();
+                _picker.setEndDate();
+                el.val('');
+              } else {
+                m = moment(newValue);
+                if (_picker.startDate > m) {
+                  _picker.setStartDate(m);
+                }
+                return _picker.setEndDate(m);
               }
-              return _picker.setEndDate(m);
             }
           });
         };


### PR DESCRIPTION
This pull request adds "clearable" option to daterangepicker. Instead of "Cancel" button closing the dialog a "Clear" button will appear that also clears the date range.

Pull request also fixes displaying "Invalid date - Invalid date" if dates are reset to `null`.