### PR TITLE
run event callback in evalAsync

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -132,7 +132,8 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
       #Ability to attach event handlers. See https://github.com/fragaria/angular-daterangepicker/pull/62
       for eventType, callbackFunction of opts.eventHandlers
-        el.on eventType, callbackFunction
+        el.on eventType, () ->
+          $scope.$evalAsync(callbackFunction)
 
       if attrs.clearable
         locale = opts.locale || {}

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -150,7 +150,9 @@
           _ref = opts.eventHandlers;
           for (eventType in _ref) {
             callbackFunction = _ref[eventType];
-            el.on(eventType, callbackFunction);
+            el.on(eventType, function() {
+              $scope.$evalAsync(callbackFunction);
+            });
           }
           if (attrs.clearable) {
             locale = opts.locale || {};


### PR DESCRIPTION
since most of the `$setViewValue` calls are wrapped in a `$timeout` function, running callback asynchronously would make it easier to use and understand. 