### PR TITLE
Upgrade to bootstrap daterangepicker 2.0

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,6 +5,11 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON("package.json")
 
+    coffeelint:
+      options:
+        configFile: 'coffeelint.json'
+      source: ['coffee/angular-daterangepicker.coffee']
+
     coffee:
       compileJoined:
         options:
@@ -14,7 +19,7 @@ module.exports = (grunt) ->
 
     watch:
       files: ['example.html', 'coffee/*.coffee']
-      tasks: ['coffee']
+      tasks: ['default']
 
     uglify:
       options:
@@ -39,6 +44,6 @@ module.exports = (grunt) ->
 
 
   # Default task(s).
-  grunt.registerTask "default", ["coffee"]
-  grunt.registerTask "develop", ["coffee", "watch"]
-  grunt.registerTask "dist", ["coffee", "ngAnnotate", "uglify"]
+  grunt.registerTask "default", ["coffeelint", "coffee"]
+  grunt.registerTask "develop", ["default", "watch"]
+  grunt.registerTask "dist", ["default", "ngAnnotate", "uglify"]

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -22,6 +22,7 @@ module.exports = (grunt) ->
       target:
         files:
           'js/angular-daterangepicker.min.js': ['js/angular-daterangepicker.js']
+
     wiredep:
       target:
         src: [

--- a/bower.json
+++ b/bower.json
@@ -20,9 +20,11 @@
   ],
   "dependencies": {
     "angular": "^1.2.17",
-    "angular-messages": "^1.2.17",
     "bootstrap": "^3.0.0",
     "bootstrap-daterangepicker": "^2.0.0"
+  },
+  "devDependencies": {
+    "angular-messages": "^1.2.17"
   },
   "overrides": {
     "bootstrap": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-daterangepicker",
-  "version": "0.1.17",
+  "version": "0.2.0",
   "homepage": "https://github.com/fragaria/angular-daterangepicker",
   "main": "js/angular-daterangepicker.js",
   "authors": [
@@ -20,10 +20,15 @@
   ],
   "dependencies": {
     "angular": "^1.2.17",
-    "bootstrap": "^v3.0.0",
-    "bootstrap-daterangepicker": "~1.3.21"
+    "bootstrap": "^3.0.0",
+    "bootstrap-daterangepicker": "^2.0.0"
   },
-  "resolutions": {
-    "moment": "~2.9.0"
+  "overrides": {
+    "bootstrap": {
+      "main": [
+        "dist/css/bootstrap.css",
+        "dist/js/bootstrap.js"
+      ]
+    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "angular": "^1.2.17",
+    "angular-messages": "^1.2.17",
     "bootstrap": "^3.0.0",
     "bootstrap-daterangepicker": "^2.0.0"
   },

--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -17,9 +17,18 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
     opts: '=options'
     clearable: '='
   link: ($scope, element, attrs, modelCtrl) ->
+    # Custom angular extend function to extend locales, so they are merged instead of overwritten
+    # angular.merge removes prototypes...
+    _mergeOpts = () ->
+      localeExtend = angular.extend.apply(angular,
+        Array.prototype.slice.call(arguments).map((opt) -> opt?.locale).filter((opt) -> !!opt))
+      extend = angular.extend.apply(angular, arguments)
+      extend.locale = localeExtend
+      extend
+
     el = $(element)
     customOpts = $scope.opts
-    opts = angular.merge({}, dateRangePickerConfig, customOpts)
+    opts = _mergeOpts({}, dateRangePickerConfig, customOpts)
     _picker = null
 
     _clear = ->
@@ -149,7 +158,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
     # Watch our options
     if attrs.options
       $scope.$watch 'opts', (newOpts) ->
-        opts = angular.merge(opts, newOpts)
+        opts = _mergeOpts(opts, newOpts)
         _init()
       , true
 
@@ -157,7 +166,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
     if attrs.clearable
       $scope.$watch 'clearable', (newClearable) ->
         if newClearable
-          opts = angular.merge(opts, {locale: {cancelLabel: opts.clearLabel}})
+          opts = _mergeOpts(opts, {locale: {cancelLabel: opts.clearLabel}})
         _init()
         el.on 'cancel.daterangepicker', (
           if newClearable

--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -73,10 +73,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     # Formatter should return just the string value of the input
     # It is used for comparison of if we should re-render
-    modelCtrl.$formatters.push (val) ->
-      if val and val.startDate
-      then _format(val)
-      else ''
+    modelCtrl.$formatters.push _format
 
     # Render should update the date picker start/end dates as necessary
     # It should also set the input element's val with $viewValue as we don't let the rangepicker do this
@@ -85,9 +82,8 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
       if modelCtrl.$modelValue and modelCtrl.$modelValue.startDate
         _setStartDate(modelCtrl.$modelValue.startDate)
         _setEndDate(modelCtrl.$modelValue.endDate)
-      else
-        _clear()
-      # Update the input
+      else _clear()
+      # Update the input with the $viewValue (generated from $formatters)
       el.val(modelCtrl.$viewValue)
 
     # This should parse the string input into an updated model object
@@ -109,7 +105,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     modelCtrl.$isEmpty = (val) ->
       # modelCtrl is empty if val is empty string
-      not val and val.length > 0
+      not (angular.isString(val) and val.length > 0)
 
     # _init has to be called anytime we make changes to the date picker options
     _init = ->
@@ -142,7 +138,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
     _initBoundaryField = (field, validator, modelField, optName) ->
       if attrs[field]
         modelCtrl.$validators[field] = (value) ->
-          validator(opts[optName], value[modelField])
+          value and validator(opts[optName], value[modelField])
         $scope.$watch field, (date) ->
           opts[optName] = if date then moment(date) else false
           _init()

--- a/example.html
+++ b/example.html
@@ -16,6 +16,7 @@
     <!-- bower:js -->
     <script src="lib/jquery/dist/jquery.js"></script>
     <script src="lib/angular/angular.js"></script>
+    <script src="lib/angular-messages/angular-messages.js"></script>
     <script src="lib/bootstrap/dist/js/bootstrap.js"></script>
     <script src="lib/moment/moment.js"></script>
     <script src="lib/bootstrap-daterangepicker/daterangepicker.js"></script>
@@ -28,37 +29,44 @@
 
     <div class="row">
         <div class="col-md-6" ng-controller="TestCtrl">
-            <form class="form-horizontal">
+            <form name="dateForm" class="form-horizontal">
                 <div class="form-group">
                     <label for="daterange1" class="control-label">Simple picker</label>
-                    <input date-range-picker id="daterange1" class="form-control date-picker" type="text"
-                           name="date" ng-model="date" required/>
+                    <input date-range-picker id="daterange1" name="daterange1" class="form-control date-picker" type="text"
+                           ng-model="date" required/>
                 </div>
-                <div class="form-group">
+                <div class="form-group" ng-class="{'has-error': dateForm.daterange2.$invalid}">
                     <label for="daterange2" class="control-label">Picker with min and max date</label>
-                    <input date-range-picker id="daterange2" class="form-control date-picker" type="text"
-                           min="'2014-02-23'" max="'2015-02-25'" name="date" ng-model="date"
+                    <input date-range-picker id="daterange2" name="daterange2" class="form-control date-picker" type="text"
+                           min="'2015-01-23'" max="'2015-08-25'" ng-model="date"
                            required/>
+                    <div class="help-block" ng-messages="dateForm.daterange2.$error">
+                        <p ng-message="min">Start date is too far in the past.</p>
+                        <p ng-message="max">End date is too far in the future.</p>
+                        <p ng-message="required">Range is required.</p>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="daterange3" class="control-label">Picker with custom locale</label>
-                    <input date-range-picker id="daterange3" class="form-control date-picker" type="text"
-                           name="date" ng-model="date" options="opts" required/>
+                    <input date-range-picker id="daterange3" name="daterange3" class="form-control date-picker" type="text"
+                           ng-model="date" options="opts" required/>
                 </div>
                 <div class="form-group">
                     <label for="daterange4" class="control-label">Clearable picker</label>
-                    <input date-range-picker id="daterange4" class="form-control date-picker" type="text"
-                           name="date" ng-model="date" clearable="true" required/>
+                    <input date-range-picker id="daterange4" name="daterange4" class="form-control date-picker" type="text"
+                           ng-model="date" clearable="true" required/>
                 </div>
                 <div class="form-group">
                     <label for="daterange5" class="control-label">Picker with custom format</label>
                     <div class="input-group col-md-6" id="daterange5">
                         <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>
-                        <input date-range-picker class="form-control date-picker" type="text"
-                           name="date2" ng-model="date2" options="{locale: {format: 'MMMM D, YYYY'}}" required/>
+                        <input date-range-picker name="daterange5" class="form-control date-picker" type="text"
+                           ng-model="date2" options="{locale: {format: 'MMMM D, YYYY'}}" required/>
                         <span class="input-group-addon"><span class="glyphicon glyphicon-chevron-down"></span></span>
                     </div>
                 </div>
+                <button type="button" class="btn" ng-click="setStartDate()">Set Start Date</button>
+                <button type="button" class="btn" ng-click="setRange()">Set Range</button>
             </form>
 
             <div class="row">
@@ -75,7 +83,7 @@
 
 
 <script>
-exampleApp = angular.module('example', ['daterangepicker']);
+exampleApp = angular.module('example', ['ngMessages', 'daterangepicker']);
 exampleApp.controller('TestCtrl', function($scope) {
     $scope.date = {
         startDate: moment().subtract(1, "days"),
@@ -104,6 +112,17 @@ exampleApp.controller('TestCtrl', function($scope) {
             'Last 7 Days': [moment().subtract(6, 'days'), moment()],
             'Last 30 Days': [moment().subtract(29, 'days'), moment()]
         }
+    };
+
+    $scope.setStartDate = function () {
+        $scope.date.startDate = moment().subtract(4, "days");
+    };
+
+    $scope.setRange = function () {
+        $scope.date = {
+            startDate: moment().subtract(5, "days"),
+            endDate: moment()
+        };
     };
 
     //Watch for date changes

--- a/example.html
+++ b/example.html
@@ -7,7 +7,7 @@
 
     <!-- bower:css -->
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" href="lib/bootstrap-daterangepicker/daterangepicker-bs3.css" />
+    <link rel="stylesheet" href="lib/bootstrap-daterangepicker/daterangepicker.css" />
     <!-- endbower -->
 
 </head>
@@ -55,7 +55,7 @@
                     <div class="input-group col-md-6" id="daterange5">
                         <span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>
                         <input date-range-picker class="form-control date-picker" type="text"
-                           name="date2" ng-model="date2" options="{format: 'MMMM D, YYYY'}" required/>
+                           name="date2" ng-model="date2" options="{locale: {format: 'MMMM D, YYYY'}}" required/>
                         <span class="input-group-addon"><span class="glyphicon glyphicon-chevron-down"></span></span>
                     </div>
                 </div>
@@ -76,13 +76,13 @@
 
 <script>
 exampleApp = angular.module('example', ['daterangepicker']);
-exampleApp.controller('TestCtrl', function($scope, $interval) {
+exampleApp.controller('TestCtrl', function($scope) {
     $scope.date = {
-        startDate: moment().subtract("days", 1),
+        startDate: moment().subtract(1, "days"),
         endDate: moment()
     };
     $scope.date2 = {
-        startDate: moment().subtract("days", 1),
+        startDate: moment().subtract(1, "days"),
         endDate: moment()
     };
 
@@ -99,11 +99,10 @@ exampleApp.controller('TestCtrl', function($scope, $interval) {
             monthNames: ['Leden', 'Únor', 'Březen', 'Duben', 'Květen', 'Červen', 'Červenec', 'Srpen', 'Září',
                 'Říjen', 'Listopad', 'Prosinec'
             ]
-
         },
         ranges: {
-            'Last 7 Days': [moment().subtract('days', 6), moment()],
-            'Last 30 Days': [moment().subtract('days', 29), moment()]
+            'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+            'Last 30 Days': [moment().subtract(29, 'days'), moment()]
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-daterangepicker",
-  "version": "0.1.17",
+  "version": "0.2.0",
   "homepage": "https://github.com/fragaria/angular-daterangepicker",
   "authors": [
     "Filip Vařecha <filip.varecha@fragaria.cz>",
@@ -12,14 +12,11 @@
   "private": false,
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "^0.7.0",
-    "grunt-contrib-uglify": "^0.3.2",
-    "grunt-contrib-watch": "^0.5.3",
-    "grunt-ng-annotate": "^0.4.0",
-    "grunt-wiredep": "^1.8.0",
-    "karma": "^0.10.2",
-    "karma-coffee-preprocessor": "^0.1.0",
-    "karma-junit-reporter": "^0.1.0",
-    "load-grunt-tasks": "^0.6.0"
+    "grunt-contrib-coffee": "^0.13.0",
+    "grunt-contrib-uglify": "^0.9.2",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-ng-annotate": "^1.0.1",
+    "grunt-wiredep": "^2.0.0",
+    "load-grunt-tasks": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "license": "MIT",
   "private": false,
   "devDependencies": {
+    "coffeelint": "^1.12.1",
     "grunt": "~0.4.1",
+    "grunt-coffeelint": "^0.0.13",
     "grunt-contrib-coffee": "^0.13.0",
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
This updates to bootstrap-daterangepicker 2.X.  Kind of debatable if this is a major release update.  ~~**There is still an issue** with the examples page all editing the same date range.  I think it's causing an endless loop somewhere, but this works well for a single date picker.~~

The biggest change being the `modelCtrl.$parsers.push` handling both an object and a string version of the date.

Should fix #99

Feel free to check it out, and play with it.  I might have missed something besides the existing bug.