### PR TITLE
quick fix when using the daterangepicker as a filter

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -72,7 +72,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
       if opts.singleDatePicker and objValue
         f(objValue)
-      else if objValue.startDate
+      else if objValue and objValue.startDate
         [f(objValue.startDate), f(objValue.endDate)].join(opts.locale.separator)
       else ''
 


### PR DESCRIPTION
i made this quick fix to allow daterangepicker to be used as a filter in ngTable, as it was my case :)