### PR TITLE
Update README to alert about breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Assuming that bower installation directory is `bower_components`. In case of oth
 <script src="bower_components/angular-daterangepicker/js/angular-daterangepicker.js"></script>
 
 <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css"/>
-<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker-bs3.css"/>
+<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker.css"/>
 ```
+**Beware: When updating from 0.1 to 0.2 the css file name changes from `daterangepicker-bs3.css` to `daterangepicker.css`**
 
 Declare dependency:
 


### PR DESCRIPTION
CSS file name was changed in the transition to 0.2, I updated the README to show the correct name and added an alert.
