### PR TITLE
Removed constant and replaced it with a provider

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -1,13 +1,28 @@
 picker = angular.module('daterangepicker', [])
 
-picker.constant('dateRangePickerConfig',
-  clearLabel: 'Clear'
-  locale:
-    separator: ' - '
-    format: 'YYYY-MM-DD'
-)
+picker.provider 'dateRangePickerOptions', ->
+  defaultOptions =
+    clearLabel: 'Clear'
+    locale:
+      separator: ' - '
+      format: 'YYYY-MM-DD'
 
-picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePickerConfig) ->
+  DefaultOptions = (options) ->
+    defaultOptions = options
+
+  @setDefaultOptions = (options) ->
+    defaultOptions = options
+    return
+
+  @$get = [ ->
+    DefaultOptions defaultOptions
+  ]
+
+  # To prevent coffeescript from returing @$get
+  # return this.$get
+  @
+
+picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePickerOptions) ->
   require: 'ngModel'
   restrict: 'A'
   scope:
@@ -28,7 +43,9 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     el = $(element)
     customOpts = $scope.opts
-    opts = _mergeOpts({}, dateRangePickerConfig, customOpts)
+    defaultOpts = angular.copy dateRangePickerOptions
+    opts = if customOpts?.locale? then _mergeOpts({}, defaultOpts, customOpts) else
+      _mergeOpts({}, dateRangePickerOptions, customOpts)
     _picker = null
 
     _clear = ->

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -3,15 +3,30 @@
 
   picker = angular.module('daterangepicker', []);
 
-  picker.constant('dateRangePickerConfig', {
-    clearLabel: 'Clear',
-    locale: {
-      separator: ' - ',
-      format: 'YYYY-MM-DD'
-    }
+  picker.provider('dateRangePickerOptions', function() {
+    var DefaultOptions, defaultOptions;
+    defaultOptions = {
+      clearLabel: 'Clear',
+      locale: {
+        separator: ' - ',
+        format: 'YYYY-MM-DD'
+      }
+    };
+    DefaultOptions = function(options) {
+      return defaultOptions = options;
+    };
+    this.setDefaultOptions = function(options) {
+      defaultOptions = options;
+    };
+    this.$get = [
+      function() {
+        return DefaultOptions(defaultOptions);
+      }
+    ];
+    return this;
   });
 
-  picker.directive('dateRangePicker', ['$compile', '$timeout', '$parse', 'dateRangePickerConfig', function($compile, $timeout, $parse, dateRangePickerConfig) {
+  picker.directive('dateRangePicker', function($compile, $timeout, $parse, dateRangePickerOptions) {
     return {
       require: 'ngModel',
       restrict: 'A',
@@ -23,7 +38,7 @@
         clearable: '='
       },
       link: function($scope, element, attrs, modelCtrl) {
-        var _clear, _init, _initBoundaryField, _mergeOpts, _picker, _setDatePoint, _setEndDate, _setStartDate, _validate, _validateMax, _validateMin, customOpts, el, opts;
+        var _clear, _init, _initBoundaryField, _mergeOpts, _picker, _setDatePoint, _setEndDate, _setStartDate, _validate, _validateMax, _validateMin, customOpts, defaultOpts, el, opts;
         _mergeOpts = function() {
           var extend, localeExtend;
           localeExtend = angular.extend.apply(angular, Array.prototype.slice.call(arguments).map(function(opt) {
@@ -37,7 +52,8 @@
         };
         el = $(element);
         customOpts = $scope.opts;
-        opts = _mergeOpts({}, dateRangePickerConfig, customOpts);
+        defaultOpts = angular.copy(dateRangePickerOptions);
+        opts = (customOpts != null ? customOpts.locale : void 0) != null ? _mergeOpts({}, defaultOpts, customOpts) : _mergeOpts({}, dateRangePickerOptions, customOpts);
         _picker = null;
         _clear = function() {
           _picker.setStartDate();
@@ -204,6 +220,6 @@
         });
       }
     };
-  }]);
+  });
 
 }).call(this);


### PR DESCRIPTION
This will allow users to set defaults in the run block.

This will accept the locale formatting if passed in for each date picker without
overwriting the locale formatting for ALL date pickers.  This allows you
to have multiple date pickers with their own date formats.