### PR TITLE
Fix for issue #183 - singleDatePicker no longer auto defaults to todays date

### DIFF
--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -88,8 +88,8 @@
               return date.format(opts.locale.format);
             }
           };
-          if (opts.singleDatePicker && objValue) {
-            return f(objValue);
+          if (opts.singleDatePicker && objValue.startDate) {
+            return f(objValue.startDate);
           } else if (objValue.startDate) {
             return [f(objValue.startDate), f(objValue.endDate)].join(opts.locale.separator);
           } else {
@@ -134,7 +134,7 @@
             autoUpdateInput: false
           }), function(start, end) {
             return $scope.$apply(function() {
-              return $scope.model = opts.singleDatePicker ? start : {
+              return $scope.model = opts.singleDatePicker ? { startDate: start } : {
                 startDate: start,
                 endDate: end
               };


### PR DESCRIPTION
Following the instructions in the wiki to always define `dateRanges:  { startDate: null, endDate: null }` i changed the model for singleDatePicker to use `{ startDate: <value> }` and the check from `objValue` to `objValue.startDate`