### PR TITLE
Update filepath in README Basic Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Assuming that bower installation directory is `bower_components`. In case of oth
 <script src="bower_components/angular-daterangepicker/js/angular-daterangepicker.js"></script>
 
 <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css"/>
-<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker-bs3.css"/>
+<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker.css"/>
 ```
 
 Declare dependency:


### PR DESCRIPTION
Include correct path to Bootstrap daterangepicker CSS file -- `daterangepicker-bs3.css` no longer exists since Jul 2015