### PR TITLE
Deep copy dateRangePickerConfig

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -28,7 +28,7 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     el = $(element)
     customOpts = $scope.opts
-    opts = _mergeOpts({}, dateRangePickerConfig, customOpts)
+    opts = _mergeOpts({}, angular.copy(dateRangePickerConfig), customOpts)
     _picker = null
 
     _clear = ->


### PR DESCRIPTION
A fix for #225. I found that the `dateRangePickerConfig` options were being mutated when multiple locales were used on one page. This caused the last locale applied to be used for all instances.