### PR TITLE
Dependencies in package.json changed to be same as in bower.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "bootstrap-daterangepicker": "1.3.23"
+    "angular": "^1.2.17",
+    "bootstrap": "^3.0.0",
+    "bootstrap-daterangepicker": "^2.0.0"
   },
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
Hi,

there are differences in dependecies versions of `package.json` and `bower.json` files. Additionaly current version of daterangepicker needs to use 

> Bootstrap Datepicker v 2.0.0 and newer

so ... i've changed `package.json` file.