### PR TITLE
daterangepicker-bs3.css -> daterangepicker.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Assuming that bower installation directory is `bower_components`. In case of oth
 <script src="bower_components/angular-daterangepicker/js/angular-daterangepicker.js"></script>
 
 <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css"/>
-<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker-bs3.css"/>
+<link rel="stylesheet" href="bower_components/bootstrap-daterangepicker/daterangepicker.css"/>
 ```
 
 Declare dependency:


### PR DESCRIPTION
daterangepicker-bs3.css is now called just daterangepicker.css in bootstrap-daterangepicker.