### PR TITLE
Date&Time picker now preselects specified input in select boxes

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -133,10 +133,14 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     # Watchers enable resetting of start and end dates
     # Update the date picker, and set a new viewValue of the model
-    $scope.$watch 'model.startDate', (n) ->
-      _setStartDate(n)
-    $scope.$watch 'model.endDate', (n) ->
-      _setEndDate(n)
+    if opts.singleDatePicker
+      $scope.$watch 'model', (n) ->
+        _setStartDate(n)
+    else
+      $scope.$watch 'model.startDate', (n) ->
+        _setStartDate(n)
+      $scope.$watch 'model.endDate', (n) ->
+        _setEndDate(n)
 
     # Add validation/watchers for our min/max fields
     _initBoundaryField = (field, validator, modelField, optName) ->


### PR DESCRIPTION
Fixed issue #200 that did not preselects the time picker with the specified model value. Based on the solution that was provided by @alexrada. 