### PR TITLE
$watchCollection instead of deep watch on options

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -152,10 +152,9 @@ picker.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRangePicker
 
     # Watch our options
     if attrs.options
-      $scope.$watch 'opts', (newOpts) ->
+      $scope.$watchCollection 'opts', (newOpts) ->
         opts = _mergeOpts(opts, newOpts)
         _init()
-      , true
 
     # Watch clearable flag
     if attrs.clearable


### PR DESCRIPTION
Using deep watch over 'options' performs deep-object-tree comparison on every $digest, which is very computationally expensive.

Other than that, it triggers a lot of 'inits' which remove and recreate the daterangepicker element on irrelevant changes somewhere in the object tree, even very deeply in Moment objects such as 'options.ranges.Today._pf.unusedTokens...'

For me that happened a lot, usually without changing anything relevant. Just creating a Moment somewhere has somehow affected other Moments and caused an 'init' (which sometimes even led to bugs, such as the calendar disappearing)

Since we just want to know if one of the options has changed, it's enough to use $watchCollection which only goes one level deep.