### PR TITLE
Implementing a custom 'moment' on 'options' definition

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -2,6 +2,7 @@ pickerModule = angular.module('daterangepicker', [])
 
 pickerModule.constant('dateRangePickerConfig',
   cancelOnOutsideClick: true
+  moment: window.moment
   locale:
     separator: ' - '
     format: 'YYYY-MM-DD'
@@ -68,7 +69,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
 
     _setDatePoint = (setter) ->
       (newValue) ->
-        if (newValue && (!moment.isMoment(newValue) || newValue.isValid()))
+        if (newValue && (!opts.moment.isMoment(newValue) || newValue.isValid()))
           newValue = moment(newValue)
         else
           # keep previous value if invalid
@@ -102,7 +103,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
 
     getViewValue =(model) ->
       f = (date) ->
-        if not moment.isMoment(date)
+        if not opts.moment.isMoment(date)
         then moment(date).format(opts.locale.format)
         else date.format(opts.locale.format)
 

--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -70,7 +70,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
     _setDatePoint = (setter) ->
       (newValue) ->
         if (newValue && (!opts.moment.isMoment(newValue) || newValue.isValid()))
-          newValue = moment(newValue)
+          newValue = opts.moment(newValue)
         else
           # keep previous value if invalid
           # set newValue = {} to default it
@@ -104,7 +104,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
     getViewValue =(model) ->
       f = (date) ->
         if not opts.moment.isMoment(date)
-        then moment(date).format(opts.locale.format)
+        then opts.moment(date).format(opts.locale.format)
         else date.format(opts.locale.format)
 
       if opts.singleDatePicker and model
@@ -141,7 +141,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
     modelCtrl.$parsers.push (viewValue) ->
       # Parse the string value
       f = (value) ->
-        date = moment(value, opts.locale.format)
+        date = opts.moment(value, opts.locale.format)
         return (date.isValid() && date) || null
 
       objValue = if opts.singleDatePicker then null else
@@ -285,7 +285,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
       if date and (min or max)
         [date, min, max] = [date, min, max].map (d) ->
           if (d)
-            moment(d)
+            opts.moment(d)
           else d
         return (!min or min.isBefore(date) or min.isSame(date, 'day')) and
                (!max or max.isSame(date, 'day') or max.isAfter(date))
@@ -309,7 +309,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
 
       if attrs[field]
         $scope.$watch field, (date) ->
-          opts[optName] = if date then moment(date) else false
+          opts[optName] = if date then opts.moment(date) else false
           if (_picker)
             _picker[optName] = opts[optName]
             $timeout -> modelCtrl.$validate()

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -78,8 +78,8 @@
         };
         _setDatePoint = function(setter) {
           return function(newValue) {
-            if (newValue && (!moment.isMoment(newValue) || newValue.isValid())) {
-              newValue = moment(newValue);
+            if (newValue && (!opts.moment.isMoment(newValue) || newValue.isValid())) {
+              newValue = opts.moment(newValue);
             } else {
               return;
             }
@@ -109,8 +109,8 @@
         getViewValue = function(model) {
           var f, viewValue;
           f = function(date) {
-            if (!moment.isMoment(date)) {
-              return moment(date).format(opts.locale.format);
+            if (!opts.moment.isMoment(date)) {
+              return opts.moment(date).format(opts.locale.format);
             } else {
               return date.format(opts.locale.format);
             }
@@ -146,7 +146,7 @@
           var f, objValue, x;
           f = function(value) {
             var date;
-            date = moment(value, opts.locale.format);
+            date = opts.moment(value, opts.locale.format);
             return (date.isValid() && date) || null;
           };
           objValue = opts.singleDatePicker ? null : {
@@ -272,7 +272,7 @@
           if (date && (min || max)) {
             ref = [date, min, max].map(function(d) {
               if (d) {
-                return moment(d);
+                return opts.moment(d);
               } else {
                 return d;
               }
@@ -299,7 +299,7 @@
           };
           if (attrs[field]) {
             return $scope.$watch(field, function(date) {
-              opts[optName] = date ? moment(date) : false;
+              opts[optName] = date ? opts.moment(date) : false;
               if (_picker) {
                 _picker[optName] = opts[optName];
                 return $timeout(function() {


### PR DESCRIPTION
Some application does not use the `moment` into global scope, so, implementing a way to specify a custom `moment` declaration in order to have the component working properly.