### PR TITLE
feat: Adds publishing to npm via travis

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log
+.node-xmlhttprequest-sync-[0-9]*
+coverage
+coverage.json
+package-lock.json
+.eslintrc.js
+.travis.yml
+.github
+.gitignore
+.gitmodules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+notifications:
+  email: false
+dist: trusty
+sudo: false
+group: beta
+language: node_js
+cache:
+  directories:
+  - "$HOME/.npm"
+jobs:
+- stage: NPM release
+  if: tag IS present
+  script: echo 'Deploying to NPM...'
+  before_deploy:
+  - npm run build
+  deploy:
+    provider: npm
+    email: chadima.jiri@gmail.com
+    skip_cleanup: true
+    api_key: "$NPM_TOKEN"
+    on:
+      repo: fragaria/angular-daterangepicker
+      tags: true
+env:
+  global:
+    secure: RHSF+oiH8IhPvTvK/Cx3WhAK3lHISDg3wdYgqJRi6EpgaYFcoiPWz540Gw3R9o0Zx58ux0xTs1MYRqFqyqA/5KMdhMw/ICyuiM3BtC6TrglDVzBtcfIwBk6dy9QzffAVvmwgeXkk6vJBVpHcB6VVuQxdsHm1B8+pm/ibr0UpFxw=

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The easiest way to install the picker is:
 ```
 bower install angular-daterangepicker --save
 ```
+## Installation via npm
+```
+npm install --save @fragaria/angular-daterangepicker
+```
+
 ## Manual installation
 This directive depends on [Bootstrap Datepicker](https://github.com/dangrossman/bootstrap-daterangepicker), [Bootstrap](http://getbootstrap.com), [Moment.js](http://momentjs.com/) and [jQuery](http://jquery.com/).
 Download dependencies above and then use [minified](js/angular-daterangepicker.min.js) or [normal](angular-daterangepicker.js) version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "angular-daterangepicker",
+  "name": "@fragaria/angular-daterangepicker",
   "version": "0.3.0",
   "homepage": "https://github.com/fragaria/angular-daterangepicker",
+  "scripts": {
+    "build": "node node_modules/grunt/lib/grunt.js dist"
+  },
   "authors": [
     "Filip Vařecha <filip.varecha@fragaria.cz>",
     "Tibor Kulčár <tibor.kulcar@fragaria.cz>",
@@ -11,6 +14,9 @@
   "description": "Angular.js wrapper for Dan Grosmann's bootstrap date range picker (https://github.com/dangrossman/bootstrap-daterangepicker).",
   "license": "MIT",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "angular": "^1.2.17",
     "bootstrap-daterangepicker": "^3.0.3"


### PR DESCRIPTION
Addresses #84 and #198 

The only possibly controversial thing is that I've namespaced the package into `@fragaria` organization on NPM. Also, Travis is enabled and should publish automatically to NPM on every pushed tag. 