### PR TITLE
fix(daterangepicker): support IE11

### DIFF
--- a/coffee/angular-daterangepicker.coffee
+++ b/coffee/angular-daterangepicker.coffee
@@ -43,7 +43,7 @@ pickerModule.directive 'dateRangePicker', ($compile, $timeout, $parse, dateRange
         updateOn = (modelCtrl.$options && modelCtrl.$options.updateOn) || ""
         allowInvalid = !!(modelCtrl.$options && modelCtrl.$options.allowInvalid)
 
-      if (!updateOn.includes("change"))
+      if (updateOn.indexOf("change") == -1)
         if (typeof modelCtrl.$overrideModelOptions == 'function')
           updateOn += " change"
           modelCtrl.$overrideModelOptions({'*':'$inherit', updateOn})

--- a/js/angular-daterangepicker.js
+++ b/js/angular-daterangepicker.js
@@ -50,7 +50,7 @@
             updateOn = (modelCtrl.$options && modelCtrl.$options.updateOn) || "";
             allowInvalid = !!(modelCtrl.$options && modelCtrl.$options.allowInvalid);
           }
-          if (!updateOn.includes("change")) {
+          if (updateOn.indexOf("change") === -1) {
             if (typeof modelCtrl.$overrideModelOptions === 'function') {
               updateOn += " change";
               return modelCtrl.$overrideModelOptions({


### PR DESCRIPTION
For IE11 it doesn't work due to unsupported methods (`.includes()`)